### PR TITLE
Create team roster page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { hot } from 'react-hot-loader';
+// import { hot } from 'react-hot-loader';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import './styles/main.css';
 import { HomePage, DashboardPage, DemoPage } from './pages';

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import './styles/main.css';
 import { HomePage, DashboardPage, DemoPage } from './pages';
+import TeamRoster from './pages/TeamRoster';
 import PrototypeForm from './components/PrototypeForm/PrototypeForm';
 import withRoot from './withRoot';
 import MainNav from './components/MainNav';
@@ -21,6 +22,7 @@ const App = () => (
         path={PATHS.PROTOTYPE_FORM}
         render={() => <PrototypeForm />}
       />
+      <Route exact path={PATHS.TEAM_ROSTER} render={() => <TeamRoster />} />
     </Switch>
   </BrowserRouter>
 );

--- a/client/src/components/MainNav/MainNav.jsx
+++ b/client/src/components/MainNav/MainNav.jsx
@@ -76,6 +76,11 @@ const MainNav = () => {
     path: '/prototype-form',
   });
 
+  const TeamRosterButton = buttonWithRoute({
+    name: 'Team Roster',
+    path: '/team',
+  });
+
   return (
     <nav className={classes.root}>
       <AppBar color="primary">
@@ -86,6 +91,7 @@ const MainNav = () => {
             <DashboardButton />
             <DemoButton />
             <PrototypeFormButton />
+            <TeamRosterButton />
           </div>
         </Toolbar>
       </AppBar>

--- a/client/src/pages/TeamRoster.jsx
+++ b/client/src/pages/TeamRoster.jsx
@@ -1,0 +1,151 @@
+import React, { useState } from 'react';
+import {
+  List,
+  ListItem,
+  ListItemText,
+  Link,
+  Paper,
+  Typography,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { SectionContainer } from '../components/common';
+
+const STYLES = makeStyles(theme => ({
+  paper: {
+    marginTop: theme.spacing.unit * 8,
+    display: 'flex',
+    flexDirection: 'column',
+    padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 3}px ${theme
+      .spacing.unit * 3}px`,
+  },
+  center: {
+    textAlign: 'center',
+  },
+}));
+
+const ROSTER = {
+  management: {
+    groupName: 'Management Team',
+    members: [
+      { name: 'Kimme Buranasombati', title: 'Project Manager', linkedin: '#' },
+      { name: 'Derek Chu', title: 'Project Manager', linkedin: '#' },
+      { name: 'Dean Church', title: 'Product Owner', linkedin: 'deanchurch' },
+      { name: 'Carolanne Fuchs', title: 'Project Manager', linkedin: '#' },
+      { name: 'Brandon Mann', title: 'Project Manager', linkedin: '#' },
+      { name: 'Martyna S.', title: 'Project Co-lead', linkedin: '#' },
+      { name: 'Sebastian Walsh', title: 'Project Manager', linkedin: '#' },
+      {
+        name: 'Bonnie Wolfe',
+        title: 'Client Relationship Manager',
+        linkedin: '#',
+      },
+    ],
+  },
+  design: {
+    groupName: 'UI / UX Team',
+    members: [
+      { name: 'Alex Chhuon', title: 'UX Designer', linkedin: '#' },
+      { name: 'Jose Lopez', title: 'Product Designer', linkedin: '#' },
+      { name: 'Domonic Moore', title: 'UX Designer', linkedin: '#' },
+      { name: 'Aaron Thomas', title: 'Design Lead', linkedin: '#' },
+      { name: 'Steve', title: 'UX Designer', linkedin: '#' },
+    ],
+  },
+  development: {
+    groupName: 'Software Development Team',
+    members: [
+      { name: 'Roland Abregorivas', title: 'Tech Lead', linkedin: '#' },
+      { name: 'Wiliam Buck', title: 'Software Developer', linkedin: 'wsbuck' },
+      { name: 'Albert Chavez', title: 'Software Developer', linkedin: '#' },
+      { name: 'Kirk Chu', title: 'Software Developer', linkedin: '#' },
+      { name: 'Luis Garcia', title: 'Software Developer', linkedin: '#' },
+      { name: 'Joel Henderson', title: 'Software Developer', linkedin: '#' },
+      {
+        name: 'Ken Lee',
+        title: 'Software Developer',
+        linkedin: 'ken-lee-7a600b110',
+      },
+      { name: 'Eva Lieu', title: 'Software Developer', linkedin: '#' },
+      { name: 'Alex Marmalichi', title: 'Software Developer', linkedin: '#' },
+      { name: 'Cat McLoughlin', title: 'Software Developer', linkedin: '#' },
+      { name: 'Linda Mejia', title: 'Software Developer', linkedin: '#' },
+      { name: 'Karl Puzon', title: 'Software Developer', linkedin: '#' },
+      { name: 'Joshua Ramirez', title: 'Software Developer', linkedin: '#' },
+      { name: 'Lamar Robinson', title: 'Software Developer', linkedin: '#' },
+      {
+        name: 'Karlen Shahinyan',
+        title: 'Software Developer',
+        linkedin: 'karlens',
+      },
+      { name: 'Louis Spencer', title: 'Software Developer', linkedin: '#' },
+      { name: 'Tyler Thome', title: 'Software Developer', linkedin: '#' },
+      { name: 'Peter Tran', title: 'Software Developer', linkedin: '#' },
+      { name: 'Dean Truong', title: 'Software Developer', linkedin: '#' },
+      { name: 'Julian Ubaldo', title: 'Software Developer', linkedin: '#' },
+    ],
+  },
+  alumni: {
+    groupName: 'Alumni',
+    members: [
+      { name: 'Marcel Hovsepian', title: 'Project Manager', linkedin: '#' },
+      { name: "Owen O'Malley", title: 'Project Manager', linkedin: '#' },
+      { name: 'Jiaxi (JC) Zhang', title: 'Project Manager', linkedin: '#' },
+    ],
+  },
+  other: {
+    groupName: 'Other Collaborators',
+    members: [
+      { name: 'Marie-Aimee Brajeux', title: '', linkedin: '#' },
+      { name: 'Diana Quach', title: '', linkedin: '#' },
+      { name: 'Wes Rowe', title: 'Consulting Engineer', linkedin: '#' },
+    ],
+  },
+};
+
+export default () => {
+  const CLASSES = STYLES();
+  const [team] = useState(ROSTER);
+  const { management, design, development, alumni, other } = team;
+  const URL_BASE_LINKEDIN = 'https://www.linkedin.com/in/';
+  const RENDER_GROUP = group => {
+    return (
+      <Paper className={CLASSES.paper}>
+        <Typography variant="h4" className={CLASSES.center}>
+          {group.groupName}
+        </Typography>
+        <List aria-label="members">
+          {group.members.map(member => {
+            return (
+              <Link
+                href={`${URL_BASE_LINKEDIN}${member.linkedin}`}
+                alt={`${member.name}'s linkedin profile`}
+              >
+                <ListItem button>
+                  <ListItemText
+                    primary={`
+                      ${member.name}
+                      ${member.title ? `-- ${member.title}` : ''}
+                    `}
+                  />
+                </ListItem>
+              </Link>
+            );
+          })}
+        </List>
+      </Paper>
+    );
+  };
+
+  return (
+    <SectionContainer>
+      <Typography variant="h3" className={CLASSES.center}>
+        TEAM ROSTER
+      </Typography>
+      {RENDER_GROUP(management)}
+      {RENDER_GROUP(design)}
+      {RENDER_GROUP(development)}
+      {RENDER_GROUP(alumni)}
+      {RENDER_GROUP(other)}
+    </SectionContainer>
+  );
+};

--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -5,6 +5,7 @@ export const PATHS = {
   HOME: '/',
   DEMO: '/demo',
   PROTOTYPE_FORM: '/prototype-form',
+  TEAM_ROSTER: '/team',
 };
 
 export default { PATHS };


### PR DESCRIPTION
Closes #197 

### Notes

- Names are ordered alphabetically (by last name) within their respective groups.
- For whatever reason, the linkedin icon from the Material-UI icon lib did not work; I instead made the entire row an anchor tag which leads directly to the member's profile.
- Members who did not provide a title were filed under the "Other Collaborators" group.
- Most members did not provide the link to their linkedin profile in time; the roster could be updated as links are provided.

Preview img:

<img width="1440" alt="Screen Shot 2019-11-14 at 8 24 24 PM" src="https://user-images.githubusercontent.com/1329249/68916908-e32bd200-071c-11ea-9df5-a1a83ae5a51d.png">
